### PR TITLE
Naprawa błędów z konwersją walut

### DIFF
--- a/controllers/front/dotpay.php
+++ b/controllers/front/dotpay.php
@@ -100,7 +100,7 @@ abstract class DotpayController extends ModuleFrontController {
         $orderAmount = (float)$this->getCorrectAmount(
             preg_replace("/[^-0-9\.]/", '', str_replace(',', '.', $orderAmount))
         );
-        $orderAmount = \Tools::convertPrice($orderAmount, $currency["id_currency"], false);
+        $orderAmount = round($orderAmount, 2); // Api allows only 2 decimal places
         $this->loader->parameter('Order:id', null);
         $this->loader->parameter('Order:amount', $orderAmount);
         $this->loader->parameter('Order:currency', $currency['iso_code']);


### PR DESCRIPTION
Usunięcie problemu ze zbyt dużą ilością miejsc po przecinku oraz podwójnym przeliczaniu między walutami. Naprawia #10 #9 #5 